### PR TITLE
Some Pirouette love.

### DIFF
--- a/bindings/AppKit/enums.js
+++ b/bindings/AppKit/enums.js
@@ -33,6 +33,14 @@ export let NSBezelStyle = makeEnum({
    SmallIconButton   : 2
 });
 
+export let NSTextAlignment = makeEnum({
+    Left             : 0,
+    Right            : 1,
+    Center           : 2,
+    Justified        : 3,
+    Natural          : 4
+});
+
 export let NSDatePickerStyle = makeEnum({
     TextFieldAndStepper:    0,
     ClockAndCalendar:       1,

--- a/bindings/AppKit/enums.js
+++ b/bindings/AppKit/enums.js
@@ -42,13 +42,13 @@ export let NSTextAlignment = makeEnum({
 });
 
 export let NSDatePickerStyle = makeEnum({
-    TextFieldAndStepper:    0,
-    ClockAndCalendar:       1,
-    TextField:              2
+    TextFieldAndStepper     : 0,
+    ClockAndCalendar        : 1,
+    TextField               : 2
 });
 
 export let NSDatePickerMode = makeEnum({
-    Single:     0,
-    Range:      1
+    Single      : 0,
+    Range       : 1
 });
 

--- a/bindings/AppKit/enums.js
+++ b/bindings/AppKit/enums.js
@@ -34,21 +34,21 @@ export let NSBezelStyle = makeEnum({
 });
 
 export let NSTextAlignment = makeEnum({
-    Left             : 0,
-    Right            : 1,
-    Center           : 2,
-    Justified        : 3,
-    Natural          : 4
+    left             : 0,
+    right            : 1,
+    center           : 2,
+    justified        : 3,
+    natural          : 4
 });
 
 export let NSDatePickerStyle = makeEnum({
-    TextFieldAndStepper     : 0,
-    ClockAndCalendar        : 1,
-    TextField               : 2
+    textFieldAndStepper     : 0,
+    clockAndCalendar        : 1,
+    textField               : 2
 });
 
 export let NSDatePickerMode = makeEnum({
-    Single      : 0,
-    Range       : 1
+    single      : 0,
+    range       : 1
 });
 

--- a/bindings/AppKit/enums.js
+++ b/bindings/AppKit/enums.js
@@ -33,3 +33,14 @@ export let NSBezelStyle = makeEnum({
    SmallIconButton   : 2
 });
 
+export let NSDatePickerStyle = makeEnum({
+    TextFieldAndStepper:    0,
+    ClockAndCalendar:       1,
+    TextField:              2
+});
+
+export let NSDatePickerMode = makeEnum({
+    Single:     0,
+    Range:      1
+});
+

--- a/bindings/AppKit/nscombobox.js
+++ b/bindings/AppKit/nscombobox.js
@@ -1,0 +1,48 @@
+// This file is part of Pirouette.  for licensing information, see the LICENSE file
+
+import { instanceSelector, instanceProperty } from '../objc';
+import { NSTextField } from 'nstextfield';
+
+export let NSComboBox = NSTextField.extendClass("NSComboBox", () => ({
+
+    // Setting display attributes
+    hasVerticalScroller: instanceProperty(),
+    intercellSpacing: instanceProperty(),
+    itemHeight: instanceProperty(),
+    numberOfVisibleItems: instanceProperty(),
+    buttonBordered: instanceProperty({ get: "isButtonBordered", set: "setButtonBordered" }),
+
+    // Working with an internal list
+    //addItemsWithObjectValues: instanceSelector("addItemsWithObjectValues:"),
+    addItemWithObjectValue: instanceSelector("addItemWithObjectValue:"),
+    insertItemWithObjectValue: instanceSelector("insertItemWithObjectValue:atIndex:"),
+    //objectValues: instanceProperty({ set: null }),
+    removeAllItems: instanceSelector(),
+    removeItemAtIndex: instanceSelector("removeItemAtIndex:"),
+    removeItemWithObjectValue: instanceSelector("removeItemWithObjectValue:"),
+    numberOfItems: instanceProperty({ set: null }),
+
+    // Manipulating the displayed list
+    indexOfItemWithObjectValue: instanceSelector("indexOfItemWithObjectValue:"),
+    itemObjectValueAtIndex: instanceSelector("itemObjectValueAtIndex:"),
+    noteNumberOfItemsChanged: instanceSelector(),
+    reloadData: instanceSelector(),
+    scrollItemAtIndexToTop: instanceSelector("scrollItemAtIndexToTop:"),
+    scrollItemAtIndexToVisible: instanceSelector("scrollItemAtIndexToVisible:"),
+
+    // Manipulating the selection
+    deselectItemAtIndex: instanceSelector("deselectItemAtIndex:"),
+    indexOfSelectedItem: instanceProperty({ set: null }),
+    objectValueOfSelectedItem: instanceProperty({ set: null }),
+    selectItemAtIndex: instanceSelector("selectItemAtIndex:"),
+    selectItemWithObjectValue: instanceSelector("selectItemWithObjectValue:"),
+
+    // Completing the textfield
+    completes: instanceProperty(),
+
+}));
+
+NSComboBox.newWithFrame = function(frame) {
+    return NSComboBox.newWith({ initWith: "Frame", args: [frame] });
+};
+

--- a/bindings/AppKit/nsdatepicker.js
+++ b/bindings/AppKit/nsdatepicker.js
@@ -1,0 +1,35 @@
+// This file is part of Pirouette.  for licensing information, see the LICENSE file
+
+import { instanceProperty, instanceSelector } from '../objc';
+import { NSControl, NSControlProxy } from 'nscontrol';
+
+export let NSDatePicker = NSControl.extendClass("NSDatePicker", () => ({
+
+    // Configuring date pickers
+    bezeled: instanceProperty({ get: 'isBezeled' }),
+    bordered: instanceProperty({ get: 'isBordered' }),
+    color: instanceProperty(),
+    drawsBackground: instanceProperty(),
+    textColor: instanceProperty(),
+    datePickerStyle: instanceProperty(),
+    datePickerElements: instanceProperty(),
+
+    // Controlling date picker range and mode
+    //calendar: instanceProperty(),
+    //locale: instanceProperty(),
+    datePickerMode: instanceProperty(),
+    //timeZone: instanceProperty(),
+
+    // Accessing object values
+    //dateValue: instanceProperty(),
+    timeInterval: instanceProperty(),
+
+    // Constraining the displayable/selectable range
+    //minDate: instanceProperty(),
+    //maxDate: instanceProperty(),
+}));
+
+NSDatePicker.newWithFrame = function (frame) {
+  return NSDatePicker.newWith({ initWith: "Frame", args: [frame] });
+};
+

--- a/bindings/Foundation/enums.js
+++ b/bindings/Foundation/enums.js
@@ -8,3 +8,51 @@ export let NSComparisonResult = makeEnum({
     same:       0,
     descending: 1
 });
+
+export let NSFormattingUnitStyle = makeEnum({
+    getTypeSignature: function() { return "i"; },
+
+    styleShort: 1,
+    styleMedium: 2,
+    styleLong: 3
+});
+
+export let NSFormattingContext = makeEnum({
+    getTypeSignature: function() { return "i"; },
+
+    unknown: 0,
+    dynamic: 1,
+    standalone: 2,
+    listItem: 3,
+    beginningOfSentence: 4,
+    middleOfSentence: 5
+});
+
+export let NSNumberFormatterBehavior = makeEnum({
+    getTypeSignature: function() { return "i"; },
+
+    default: 0,
+    version_10_0: 1000,
+    version_10_4: 1040
+});
+
+export let NSNumberFormatterStyle = makeEnum({
+    getTypeSignature: function() { return "i"; },
+
+    noStyle: 0,
+    decimal: 1,
+    currency: 2,
+    percent: 3,
+    scientific: 4,
+    spellOut: 5
+});
+
+export let NSNumberFormatterPadPosition = makeEnum({
+    getTypeSignature: function() { return "i"; },
+
+    beforePrefix: 0,
+    afterPrefix: 1,
+    beforeSuffix: 2,
+    afterSuffix: 3
+});
+

--- a/bindings/Foundation/nsformatter.js
+++ b/bindings/Foundation/nsformatter.js
@@ -1,0 +1,21 @@
+// This file is part of Pirouette.  for licensing information, see the LICENSE file
+
+import { instanceSelector } from '../objc';
+import { NSObject } from 'nsobject';
+
+export let NSFormatter = NSObject.extendClass("NSFormatter", {
+
+    // Textual representation of cell content
+    stringForObjectValue: instanceSelector("stringForObjectValue:"),
+    attributedStringForObjectValue: instanceSelector("attributedStringForObjectValue:withDefaultAttributes:"),
+    editingStringForObjectValue: instanceSelector("editingStringForObjectValue:"),
+
+    // Object equivalent to textual representation
+    //getObjectValue: instanceSelector("getObjectValue:"),
+    
+
+    // Dynamic cell editing
+    //isPartialStringValid: instanceSelector("isPartialStringValid:newEditingString:errorDescription:"),
+    //isPartialStringValidForRange: instanceSelector("isPartialStringValid:proposedSelectedRange:originalString:originalSelectedRange:errorDescription:"),
+});
+

--- a/bindings/Foundation/nsnumberformatter.js
+++ b/bindings/Foundation/nsnumberformatter.js
@@ -1,0 +1,95 @@
+// This file is part of Pirouette.  for licensing information, see the LICENSE file
+
+import { staticProperty, instanceProperty, instanceSelector, sig } from '../objc';
+import { NSObject } from 'nsobject';
+import { NSFormatter } from 'nsformatter';
+
+export let NSNumberFormatter = NSFormatter.extendClass("NSNumberFormatter", {
+
+    // Configuring formatter behavior and style
+    formatterBehavior: instanceProperty(),
+    numberStyle: instanceProperty(),
+    generatesDecimalNumbers: instanceProperty(),
+
+    // Converting between number and strings
+    //getObjectValue: instanceSelector("getObjectValue:forString:range:error:"),
+    numberFromString: instanceSelector("numberFromString:"),
+    stringFromNumber: instanceSelector("stringFromNumber:"),
+    localizedStringFromNumber: instanceSelector("localizedStringFromNumber:numberStyle:"),
+
+    // Managing localization of numbers
+    locale: instanceProperty(),
+
+    // Configuring rounding behavior
+    roundingIncrement: instanceProperty(),
+    roundingMode: instanceProperty(),
+
+    // Configuring numeric formats
+    formattingContext: instanceProperty(),
+    formatWidth: instanceProperty(),
+    negativeFormat: instanceProperty(),
+    positiveFormat: instanceProperty(),
+    multiplier: instanceProperty(),
+
+    // Configuring numeric symbols
+    percentSymbol: instanceProperty(),
+    perMillSymbol: instanceProperty(),
+    minusSign: instanceProperty(),
+    plusSign: instanceProperty(),
+    exponentSymbol: instanceProperty(),
+    zeroSymbol: instanceProperty(),
+    nilSymbol: instanceProperty(),
+    notANumberSymbol: instanceProperty(),
+    negativeInfinitySymbol: instanceProperty(),
+    positiveInfinitySymbol: instanceProperty(),
+
+    // Configuring the format of currency
+    currencySymbol: instanceProperty(),
+    currencyCode: instanceProperty(),
+    internationalCurrencySymbol: instanceProperty(),
+    currencyGroupingSeparator: instanceProperty(),
+
+    // Configuring numeric preffixes and suffixes
+    positivePrefix: instanceProperty(),
+    positiveSuffix: instanceProperty(),
+    negativePrefix: instanceProperty(),
+    negativeSuffix: instanceProperty(),
+
+    // Configuring separators and grouping size
+    groupingSeparator: instanceProperty(),
+    useGroupingSeparator: instanceProperty(),
+    decimalSeparator: instanceProperty(),
+    alwaysShowDecimalSeparator: instanceProperty(),
+    currencyDecimalSeparator: instanceProperty(),
+    groupingSize: instanceProperty(),
+    secondaryGroupingSize: instanceProperty(),
+
+    // Managing the padding of numbers
+    paddingCharacter: instanceProperty(),
+    paddingPosition: instanceProperty(),
+
+    // Managing input and output attributes
+    allowsFloats: instanceProperty(),
+    minimum: instanceProperty(),
+    maximum: instanceProperty(),
+    minimumIntegerDigits: instanceProperty(),
+    minimumFractionDigits: instanceProperty(),
+    maximumIntegerDigits: instanceProperty(),
+    maximumFractionDigits: instanceProperty(),
+
+    // Configuring significant digits
+    usesSignificantDigits: instanceProperty(),
+    minimumSignificantDigits: instanceProperty(),
+    maximumSignificantDigits: instanceProperty(),
+
+    // Managing leniency behavior
+    lenient: instanceProperty({ get: 'isLenient' }),
+
+    // Managing the validation of partial numeric strings
+    partialStringValidationEnabled: instanceProperty({ get: 'isPartialStringValidationEnabled' }),
+});
+
+NSNumberFormatter.newFormatter = function() {
+    return NSNumberFormatter.new();
+};
+

--- a/bindings/Foundation/nsobject.js
+++ b/bindings/Foundation/nsobject.js
@@ -36,6 +36,11 @@ NSObject.getTypeSignature = function() {
   return "@";
 };
 
+NSObject.new = function() {
+    let instance = new this.prototype.constructor;
+    return instance;
+};
+
 NSObject.newWith = function(newInfo) {
   let methodname = `initWith${newInfo.initWith}`;
   let meth = this.prototype[methodname];

--- a/bindings/Foundation/nsobject.js
+++ b/bindings/Foundation/nsobject.js
@@ -42,7 +42,7 @@ NSObject.new = function() {
     let instance = new this.prototype.constructor;
 
     let initMeth = this.prototype['init']; // init is guaranteed to always exist.
-    initMeth.apply(instance, initMeth);
+    initMeth.call(instance);
 
     return instance;
 };

--- a/bindings/Foundation/nsobject.js
+++ b/bindings/Foundation/nsobject.js
@@ -1,6 +1,6 @@
 // This file is part of Pirouette.  for licensing information, see the LICENSE file
 
-import { extendClass, createExtendClass } from '../objc';
+import { extendClass, createExtendClass, instanceSelector } from '../objc';
 
 import * as objc_internal from '@objc_internal';
 let PirouetteObject = objc_internal.PirouetteObject;
@@ -23,7 +23,9 @@ export let NSObject = extendClass("NSObject", PirouetteObject, () => ({
 
     toString: function () {
       return `[${this.constructor._ck_register} ${this.handle.toString()}]`;
-    }
+    },
+
+    init: instanceSelector()
 
 }));
 
@@ -38,6 +40,10 @@ NSObject.getTypeSignature = function() {
 
 NSObject.new = function() {
     let instance = new this.prototype.constructor;
+
+    let initMeth = this.prototype['init']; // init is guaranteed to always exist.
+    initMeth.apply(instance, initMeth);
+
     return instance;
 };
 

--- a/bindings/appkit.js
+++ b/bindings/appkit.js
@@ -3,7 +3,7 @@
 // not yet
 //import "@framework AppKit";
 
-export { NSButtonType, NSBezelStyle } from 'AppKit/enums';
+export { NSButtonType, NSBezelStyle, NSDatePickerStyle, NSDatePickerMode } from 'AppKit/enums';
 export { NSActionCell }               from 'AppKit/nsactioncell';
 export { NSAlert }                    from 'AppKit/nsalert';
 export { NSAnimation }                from 'AppKit/nsanimation';
@@ -30,6 +30,7 @@ export { NSColorList }                from 'AppKit/nscolorlist';
 //export { NSColorPanel }               from 'AppKit/nscolorpanel';
 export { NSControl }                  from 'AppKit/nscontrol';
 export { NSController }               from 'AppKit/nscontroller';
+export { NSDatePicker }               from 'AppKit/nsdatepicker';
 export { NSScrollView }               from 'AppKit/nsscrollview';
 export { NSSlider }                   from 'AppKit/nsslider';
 export { NSTableCellView }            from 'AppKit/nstablecellview';

--- a/bindings/appkit.js
+++ b/bindings/appkit.js
@@ -28,6 +28,7 @@ export { NSCollectionView }           from 'AppKit/nscollectionview';
 export { NSColor }                    from 'AppKit/nscolor';
 export { NSColorList }                from 'AppKit/nscolorlist';
 //export { NSColorPanel }               from 'AppKit/nscolorpanel';
+export { NSComboBox }                 from 'AppKit/nscombobox';
 export { NSControl }                  from 'AppKit/nscontrol';
 export { NSController }               from 'AppKit/nscontroller';
 export { NSDatePicker }               from 'AppKit/nsdatepicker';

--- a/bindings/appkit.js
+++ b/bindings/appkit.js
@@ -3,7 +3,7 @@
 // not yet
 //import "@framework AppKit";
 
-export { NSButtonType, NSBezelStyle, NSDatePickerStyle, NSDatePickerMode } from 'AppKit/enums';
+export { NSButtonType, NSBezelStyle, NSTextAlignment, NSDatePickerStyle, NSDatePickerMode } from 'AppKit/enums';
 export { NSActionCell }               from 'AppKit/nsactioncell';
 export { NSAlert }                    from 'AppKit/nsalert';
 export { NSAnimation }                from 'AppKit/nsanimation';

--- a/bindings/foundation.js
+++ b/bindings/foundation.js
@@ -5,7 +5,9 @@
 
 export { NSComparisonResult } from 'Foundation/enums';
 export { NSBundle } from 'Foundation/nsbundle';
+export { NSFormatter } from 'Foundation/nsformatter';
 export { NSIndexPath } from 'Foundation/nsindexpath';
+export { NSNumberFormatter } from 'Foundation/nsnumberformatter';
 export { NSObject } from 'Foundation/nsobject';
 export { NSProcessInfo } from 'Foundation/nsprocessinfo';
 export { NSPoint } from 'Foundation/nspoint';


### PR DESCRIPTION
Things to observe:

1. enums style: in Foundation lower case has been used, but in AppKit upper casing the first char is the followed style (i.e. "default" vs "Default"). Which one should we follow?

2. I added a NSObject.new() method for objects that have parameterless init() methods (say, NSNumberFormatter). Does the naming looks ok?

3. I have samples for the new UI wrappers, but I can only commit them after I have these bits in echo-js ;)